### PR TITLE
Improve language support

### DIFF
--- a/src/flow-i18n.js
+++ b/src/flow-i18n.js
@@ -214,6 +214,7 @@ let config = {
 		{"title":"Norwegian", "locale": "no" },
 		{"title":"Polski", "locale": "pl" },
 		{"title":"PortuguÃªs", "locale": "pt" },
+		{"title":"PortuguÃªs (Brazil)", "locale": "pt_BR" },
 		{"title":"Romanian", "locale": "ro" },
 		{"title":"Русский", "locale": "ru" },
 		{"title":"Slovak", "locale": "sk" },

--- a/src/flow-i18n.js
+++ b/src/flow-i18n.js
@@ -227,14 +227,13 @@ let config = {
 		{"title":"Urdu", "locale": "ur" },
 		{"title":"Vietnamese", "locale": "vi" },
 		{"title":"Mongolian", "locale": "mn" },
-		{"title":"中文", "locale": "zh_HANS" },
-		{"title":"繁體中文", "locale": "zh_HANT" }
+		{"title":"中文", "locale": "zh" }
 	],
 	aliases : {
 		"en-GB": "en",
 		"en-US": "en",
-		"zh-CN": "zh_HANS",
-		"zh-TW": "zh_HANT"
+		"zh-CN": "zh",
+		"zh-TW": "zh"
 	}
 
 }


### PR DESCRIPTION
According to translation discussion on Discord, here are two improvements:

- Add Portuguese (Brazil) flavour
- Cleanup Chinese to simplify naming just as `zh`